### PR TITLE
update license

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,12 +7,7 @@
     "url": "https://github.com/jonschlinkert"
   },
   "homepage": "https://github.com/jonschlinkert/verbalize",
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://github.com/jonschlinkert/verbalize/blob/master/LICENSE-MIT"
-    }
-  ],
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/jonschlinkert/verbalize.git"


### PR DESCRIPTION
using `licenses` field and `license` as object is deprecated in npm@v2.10+

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/