### PR TITLE
Don't require missing logger

### DIFF
--- a/lib/plugins/index.js
+++ b/lib/plugins/index.js
@@ -9,7 +9,6 @@ require = utils; // eslint-disable-line no-native-reassign
  */
 
 require('base-is-enabled', 'isEnabled');
-require('./base-logger', 'logger');
 require('./colors', 'colors');
 require('./handler', 'handler');
 require('./rainbow', 'rainbow');


### PR DESCRIPTION
This currently breaks assemble.io which requires base-cli, which requires base-logger, which requires the #event-logger branch of this repository.

Cheers
Patrick